### PR TITLE
Split checkout into shipping, payment and purchase steps

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -369,11 +369,11 @@ function renderCartPage(){
 }
 
 /* =============================================
- Checkout
+ Datos de envío
 ============================================= */
-function setupCheckout(){
-  const form = $('#checkoutForm'); const sumEl = $('#checkoutSummary'); if(!form) return;
-  const { cart, value, items } = getCartTotals();
+function setupShipping(){
+  const form = $('#shippingForm'); const sumEl = $('#shippingSummary'); if(!form) return;
+  const { cart, value } = getCartTotals();
   sumEl.textContent = `${cart.length} artículos · Total ${money(value)}`;
   form.addEventListener('submit', (e) => {
     e.preventDefault();
@@ -381,19 +381,35 @@ function setupCheckout(){
     if(!data.nombre || !data.email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(data.email)){
       alert('Revisa nombre y email válido.'); return;
     }
-    const orderId = 'ORD-' + Math.random().toString(36).slice(2,8).toUpperCase();
-    pushDL({ event: 'purchase', ecommerce: { transaction_id: orderId, value: +value.toFixed(2), currency: 'EUR', items } });
-    sessionStorage.setItem('last_order', JSON.stringify({ orderId, value, items, email: data.email, nombre: data.nombre }));
-    clearCart();
-    location.href = 'gracias.html';
+    sessionStorage.setItem('shipping', JSON.stringify(data));
+    location.href = 'pago.html';
   });
 }
 
 /* =============================================
- Gracias
+ Pago
 ============================================= */
-function renderThanks(){
-  const box = $('#thanksBox'); if(!box) return;
+function setupPayment(){
+  const form = $('#paymentForm'); const sumEl = $('#paymentSummary'); if(!form) return;
+  const { cart, value, items } = getCartTotals();
+  sumEl.textContent = `${cart.length} artículos · Total ${money(value)}`;
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const shipping = JSON.parse(sessionStorage.getItem('shipping')||'{}');
+    const orderId = 'ORD-' + Math.random().toString(36).slice(2,8).toUpperCase();
+    pushDL({ event: 'purchase', ecommerce: { transaction_id: orderId, value: +value.toFixed(2), currency: 'EUR', items } });
+    sessionStorage.setItem('last_order', JSON.stringify({ orderId, value, items, ...shipping }));
+    sessionStorage.removeItem('shipping');
+    clearCart();
+    location.href = 'compra.html';
+  });
+}
+
+/* =============================================
+ Compra
+============================================= */
+function renderPurchase(){
+  const box = $('#purchaseBox'); if(!box) return;
   const raw = sessionStorage.getItem('last_order');
   if(!raw){ box.innerHTML = '<p class="muted">No hay pedido reciente.</p>'; return; }
   const { orderId, value, items, nombre } = JSON.parse(raw);
@@ -417,8 +433,9 @@ window.addEventListener('DOMContentLoaded', () => {
   if(page==='shop') renderShop();
   if(page==='blog') renderBlog();
   if(page==='cart') renderCartPage();
-  if(page==='checkout') setupCheckout();
-  if(page==='thanks') renderThanks();
+  if(page==='shipping') setupShipping();
+  if(page==='payment') setupPayment();
+  if(page==='purchase') renderPurchase();
   if(page==='search') renderSearchPage();
   if(page==='product') renderProductPage(); // ← ficha de producto
 });

--- a/carrito.html
+++ b/carrito.html
@@ -32,7 +32,7 @@
 <div id="cartList" class="stack"></div>
 <div class="row between center-v" style="margin-top:12px;">
 <strong>Total: <span id="cartTotal">0 €</span></strong>
-<a id="goCheckout" class="btn primary" href="checkout.html">Ir al checkout</a>
+<a id="goCheckout" class="btn primary" href="envio.html">Ir a envío</a>
 </div>
 </main>
 

--- a/compra.html
+++ b/compra.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Tienda Demo — ¡Gracias!</title>
+<title>Tienda Demo — Compra completada</title>
 <link rel="stylesheet" href="assets/css/styles.css" />
-<meta name="description" content="Gracias por tu compra (simulada)." />
+<meta name="description" content="Resumen de la compra simulada." />
 </head>
-<body data-page="thanks">
+<body data-page="purchase">
 <header class="site-header">
 <div class="container row between center-v">
 <a class="brand" href="index.html">Tienda <span>Demo</span></a>
@@ -28,7 +28,7 @@
 
 <main class="container pad-y narrow">
 <h1 class="page-title">¡Gracias por tu compra!</h1>
-<div id="thanksBox"></div>
+<div id="purchaseBox"></div>
 </main>
 
 

--- a/envio.html
+++ b/envio.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Tienda Demo — Checkout</title>
+<title>Tienda Demo — Datos de envío</title>
 <link rel="stylesheet" href="assets/css/styles.css" />
-<meta name="description" content="Checkout simulado con evento purchase en dataLayer." />
+<meta name="description" content="Paso de datos de envío previo al pago." />
 </head>
-<body data-page="checkout">
+<body data-page="shipping">
 <header class="site-header">
 <div class="container row between center-v">
 <a class="brand" href="index.html">Tienda <span>Demo</span></a>
@@ -27,9 +27,9 @@
 
 
 <main class="container pad-y narrow">
-<h1 class="page-title">Checkout</h1>
-<p id="checkoutSummary" class="muted"></p>
-<form id="checkoutForm" class="form card" novalidate>
+<h1 class="page-title">Datos de envío</h1>
+<p id="shippingSummary" class="muted"></p>
+<form id="shippingForm" class="form card" novalidate>
 <label>Nombre
 <input required name="nombre" placeholder="Tu nombre" />
 </label>
@@ -39,8 +39,8 @@
 <label>Dirección
 <input required name="direccion" placeholder="Calle Falsa 123" />
 </label>
-<button class="btn primary" type="submit">Pagar (simulado)</button>
-<p class="form-note">No hay pago real. Al enviar verás la confirmación y se emitirá un evento <code>purchase</code> al <code>dataLayer</code>.</p>
+<button class="btn primary" type="submit">Continuar a pago</button>
+<p class="form-note">Paso simulado. Tus datos se usarán en el pago.</p>
 </form>
 </main>
 

--- a/pago.html
+++ b/pago.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Tienda Demo — Datos de pago</title>
+<link rel="stylesheet" href="assets/css/styles.css" />
+<meta name="description" content="Paso de datos de pago simulado." />
+</head>
+<body data-page="payment">
+<header class="site-header">
+<div class="container row between center-v">
+<a class="brand" href="index.html">Tienda <span>Demo</span></a>
+<nav class="main-nav">
+<a href="index.html">Inicio</a>
+<a href="tienda.html">Tienda</a>
+<a href="blog.html">Blog</a>
+<a href="contacto.html">Contacto</a>
+<a href="carrito.html">Carrito (<span id="cartCount">0</span>)</a>
+</nav>
+<div class="search">
+<input id="searchInput" type="search" placeholder="Buscar productos o posts…" aria-label="Buscar" />
+<div id="searchResults" class="search-results" aria-live="polite"></div>
+</div>
+</div>
+</header>
+
+<main class="container pad-y narrow">
+<h1 class="page-title">Datos de pago</h1>
+<p id="paymentSummary" class="muted"></p>
+<form id="paymentForm" class="form card" novalidate>
+<label>Número de tarjeta
+<input required name="tarjeta" placeholder="1111 2222 3333 4444" />
+</label>
+<label>CVV
+<input required name="cvv" placeholder="123" />
+</label>
+<button class="btn primary" type="submit">Finalizar compra</button>
+<p class="form-note">No hay pago real. Al enviar verás la confirmación y se emitirá un evento <code>purchase</code> al <code>dataLayer</code>.</p>
+</form>
+</main>
+
+<footer class="site-footer">
+<div class="container row between center-v">
+<small>© <span id="year"></span> Tienda Demo</small>
+<small><a href="contacto.html">Contacto</a></small>
+</div>
+</footer>
+
+<script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace single checkout with separate shipping (`envio.html`) and payment (`pago.html`) pages
- add final purchase confirmation page (`compra.html`) and related JS logic
- update cart link and checkout logic to flow through new steps

## Testing
- `node --check assets/js/app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b540dfe7388333a32193d986316ade